### PR TITLE
Calling startActivity() from outside of an Activity context fix

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
@@ -243,7 +243,7 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
                 if (intent.resolveActivity(context.getPackageManager()) != null) {
                     context.startActivity(intent);
                     // Thread-safe.
-                    callback.invoke(fileName);
+                    callback.invoke(null, fileName);
                 } else {
                     activityNotFoundMessage("Activity not found to handle: " + contentUri.toString() + " (" + mimeType + ")");
                 }

--- a/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
@@ -242,18 +242,22 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
 
                 if (intent.resolveActivity(context.getPackageManager()) != null) {
                     context.startActivity(intent);
+                    // Thread-safe.
+                    callback.invoke(fileName);
+                } else {
+                    activityNotFoundMessage("Activity not found to handle: " + contentUri.toString() + " (" + mimeType + ")");
                 }
-
-                // Thread-safe.
-                callback.invoke(fileName);
             } catch (ActivityNotFoundException e) {
-                System.out.println("ERROR");
-                System.out.println(e.getMessage());
-                callback.invoke(e.getMessage());
-                //e.printStackTrace();
+                activityNotFoundMessage(e.getMessage());
             }
 
         }
 
+        private void activityNotFoundMessage(String message) {
+            System.out.println("ERROR");
+            System.out.println(message);
+            callback.invoke(message);
+            //e.printStackTrace();
+        }
     }
 }

--- a/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
@@ -59,7 +59,7 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
   public String getName() {
     return "RNReactNativeDocViewer";
   }
-    
+
   @ReactMethod
   public void openDoc(ReadableArray args, Callback callback) {
       final ReadableMap arg_object = args.getMap(0);
@@ -97,7 +97,7 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
             callback.invoke(e.getMessage());
        }
   }
-    
+
     // used for all downloaded files, so we can find and delete them again.
     private final static String FILE_TYPE_PREFIX = "PP_";
     /**
@@ -192,12 +192,12 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
 
         return mimeType;
     }
-    
+
   private class FileDownloaderAsyncTask extends AsyncTask<Void, Void, File> {
         private final Callback callback;
         private final String url;
         private final String fileName;
-       
+
         public FileDownloaderAsyncTask(Callback callback,
                 String url, String fileName) {
             super();
@@ -223,10 +223,11 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
                 return;
             }
 
-            Context context = getReactApplicationContext().getBaseContext();
+            Context context = getCurrentActivity();
+
             // mime type of file data
             String mimeType = getMimeType(url);
-            if (mimeType == null) {
+            if (mimeType == null || context == null) {
                 return;
             }
             try {
@@ -235,11 +236,14 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
                 System.out.println(contentUri);
 
                 Intent intent = new Intent(Intent.ACTION_VIEW);
-                intent.setDataAndType(contentUri, mimeType);  
+                intent.setDataAndType(contentUri, mimeType);
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                context.startActivity(intent);
-          
+
+                if (intent.resolveActivity(context.getPackageManager()) != null) {
+                    context.startActivity(intent);
+                }
+
                 // Thread-safe.
                 callback.invoke(fileName);
             } catch (ActivityNotFoundException e) {


### PR DESCRIPTION
Application contexts are not allowed to start Activities unless the Intent contains the FLAG_ACTIVITY_NEW_TASK flag.

Works on Android 7.

On emulator and device with Android 6 we get fatal exception:
```
android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
                                                     at android.app.ContextImpl.startActivity(ContextImpl.java:672)
                                                     at android.app.ContextImpl.startActivity(ContextImpl.java:659)
                                                     at android.content.ContextWrapper.startActivity(ContextWrapper.java:331)
                                                     at com.reactlibrary.RNReactNativeDocViewerModule$FileDownloaderAsyncTask.onPostExecute(RNReactNativeDocViewerModule.java:241)
                                                     at com.reactlibrary.RNReactNativeDocViewerModule$FileDownloaderAsyncTask.onPostExecute(RNReactNativeDocViewerModule.java:196)
```

Current activity should be used instead application context as setting FLAG_ACTIVITY_NEW_TASK flag is not recommended.
