### PR TITLE
Fix cannot detect mime type in android

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
@@ -177,7 +177,7 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
     private static String getMimeType(String url) {
         String mimeType = null;
 
-        String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+        String extension = MimeTypeMap.getFileExtensionFromUrl(Uri.encode(url));
         if (extension != null) {
             MimeTypeMap mime = MimeTypeMap.getSingleton();
             mimeType = mime.getMimeTypeFromExtension(extension);


### PR DESCRIPTION
The MimeTypeMap.getFileExtensionFromUrl return null if url contain space, example local url 
> file:///data/data/com.example/cache/test copy.txt
```
String extension = MimeTypeMap.getFileExtensionFromUrl(url);
        if (extension != null) {
            MimeTypeMap mime = MimeTypeMap.getSingleton();
            mimeType = mime.getMimeTypeFromExtension(extension);
        }
```
This is a simple fix to prevent the document open by pdf application as the default mime type is "pdf/application" when mime type is null.

```
 if (mimeType == null) {
            mimeType = "application/pdf";
            System.out.println("Mime Type (default): " + mimeType);
        }

```

