### PR TITLE
Fix openDoc doesn't work with modal (iOS)

### DIFF
--- a/ios/RNReactNativeDocViewer.m
+++ b/ios/RNReactNativeDocViewer.m
@@ -88,6 +88,9 @@ RCT_EXPORT_METHOD(openDoc:(NSArray *)array callback:(RCTResponseSenderBlock)call
                 callback(@[[NSNull null], array]);
             }
             UIViewController* root = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+            while (root.presentedViewController) {
+                root = [root presentedViewController];
+            }
             [root presentViewController:cntr animated:YES completion:nil];
         });
         
@@ -141,6 +144,9 @@ RCT_EXPORT_METHOD(openDocBinaryinUrl:(NSArray *)array callback:(RCTResponseSende
                 callback(@[[NSNull null], @"Data"]);
             }
             UIViewController* root = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+            while (root.presentedViewController) {
+                root = [root presentedViewController];
+            }
             [root presentViewController:cntr animated:YES completion:nil];
         });
         
@@ -189,6 +195,9 @@ RCT_EXPORT_METHOD(openDocb64:(NSArray *)array callback:(RCTResponseSenderBlock)c
                 callback(@[[NSNull null], @"Data"]);
             }
             UIViewController* root = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+            while (root.presentedViewController) {
+                root = [root presentedViewController];
+            }
             [root presentViewController:cntr animated:YES completion:nil];
         });
         


### PR DESCRIPTION
The `openDoc` method doesn't work when react-native's Modal component is open.
```
Warning: Attempt to present <QLPreviewController: 0x7f94bc0bf000> on <UIViewController: 0x7f94b8d0dbe0> whose view is not in the window hierarchy!
```

This is a fix to use `presentedViewController` if it's available.
```objc
UIViewController* root = [[[UIApplication sharedApplication] keyWindow] rootViewController];
while (root.presentedViewController) {
    root = [root presentedViewController];
}
[root presentViewController:cntr animated:YES completion:nil];
```
