### PR TITLE
Update podspec and CocoaPods installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Changelog:
 
 `$ react-native link react-native-doc-viewer`
 
+### CocoaPods installation 
+
+If your project uses CocoaPods to manage React installation (especially with Expo-detached project), most likely you will run into issue with header files not found as described here (https://docs.expo.io/versions/latest/guides/expokit.html#changing-native-dependencies "Changing Native Dependencies"). It will be helpful to follow these steps to have it compiled successfully:
+
+1. `npm install react-native-doc-viewer --save`
+
+2. Add the plugin dependency to your Podfile, pointing at the path where NPM installed it:
+
+`pod 'RNReactNativeDocViewer', path: '../node_modules/react-native-doc-viewer'`
+
+3. Run `pod install`
 
 ### Manual installation
 

--- a/RNReactNativeDocViewer.podspec
+++ b/RNReactNativeDocViewer.podspec
@@ -6,18 +6,17 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNReactNativeDocViewer
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/philipphecht/react-native-doc-viewer"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNReactNativeDocViewer.git", :tag => "master" }
-  s.source_files  = "RNReactNativeDocViewer/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/philipphecht/react-native-doc-viewer.git", :tag => "master" }
+  s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
 
 
   s.dependency "React"
-  #s.dependency "others"
 
 end
 


### PR DESCRIPTION
Background: 
Recently I detached a Expo project to ExpoKit to use this module and spent too much time figuring out why React/RCTEventEmitter.h header file was not found and compiled. In the end, I has success by relying on CocoaPods to manage my dependencies. 

Changes: 
- A proper podspec file that CocoaPods can understand and run. 
- Additional installation instruction for CocoaPods. 