### PR TITLE
Get mime type straight from file type if specified

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
@@ -325,7 +325,10 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
             Context context = getCurrentActivity();
            String mimeType;
             // mime type of file data
-            if (fileName != null && fileType != null) {
+            if (fileType != null) {
+                // If file type is already specified, should just take the mimeType from it
+                mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileType);
+            } else if (fileName != null && fileType != null) {
                mimeType = getMimeType(fileName + "." +fileType);
             } else {
               mimeType = getMimeType(url);

--- a/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNReactNativeDocViewerModule.java
@@ -328,8 +328,6 @@ public class RNReactNativeDocViewerModule extends ReactContextBaseJavaModule {
             if (fileType != null) {
                 // If file type is already specified, should just take the mimeType from it
                 mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileType);
-            } else if (fileName != null && fileType != null) {
-               mimeType = getMimeType(fileName + "." +fileType);
             } else {
               mimeType = getMimeType(url);
             }


### PR DESCRIPTION
Doesn't make sense now to get MimeType from the filename/url if file type is already specified by the user.