### PR TITLE
change default export to avoid import errors in testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,4 @@
 
 import { NativeModules } from 'react-native';
 const RNReactNativeDocViewer = NativeModules.RNReactNativeDocViewer;
-export default {
-  openDoc: RNReactNativeDocViewer.openDoc,
-  openDocb64: RNReactNativeDocViewer.openDocb64,
-  playMovie: RNReactNativeDocViewer.playMovie,
-  openDocBinaryinUrl:RNReactNativeDocViewer.openDocBinaryinUrl,
-  testModule: RNReactNativeDocViewer.testModule
-}
+export default RNReactNativeDocViewer;


### PR DESCRIPTION
default export `RNReactNativeDocViewer` without specifying attributes to avoid erroring when `NativeModules.RNReactNativeDocViewer` is undefined (this occurs when importing while running unit tests, for example).

Resolves #89 