### PR TITLE
Remove unused import ReactWebViewManager

### DIFF
--- a/android/src/main/java/com/philipphecht/RNDocViewerModule.java
+++ b/android/src/main/java/com/philipphecht/RNDocViewerModule.java
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.views.webview.ReactWebViewManager;
 
 /* bridge react native
 int size();


### PR DESCRIPTION
WebViewManager has been moved out of React Native, and looks like it is also unused. So removing the import. This is needed for moving React Native apps to 0.60 and depend on this package.