### PR TITLE
remove redundant error that make error

### DIFF
--- a/android/src/main/java/com/philipphecht/RNDocViewerModule.java
+++ b/android/src/main/java/com/philipphecht/RNDocViewerModule.java
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.views.webview.ReactWebViewManager;
 
 /* bridge react native
 int size();


### PR DESCRIPTION
Hello, please accept my pull request, i just remove "import com.facebook.react.views.webview.ReactWebViewManager;", that packages make error, because that packages already not available, and its redundant import