### PR TITLE
Remove webview pacakge

### DIFF
--- a/android/src/main/java/com/philipphecht/RNDocViewerModule.java
+++ b/android/src/main/java/com/philipphecht/RNDocViewerModule.java
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.views.webview.ReactWebViewManager;
 
 /* bridge react native
 int size();

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "react-native-doc-viewer",
   "version": "2.7.8",


### PR DESCRIPTION
WebView is deprecated from RN 0.60.0  and we don't use WebView package in react-native-doc-viewer package.